### PR TITLE
Add Cursor Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Do open an issue if you're interested in a notification channel being implemente
 
 # 👨🏻‍💻 Installation
 
-Through `go install` (easiest if you have Go 1.21 installed):
+Through `go install` (easiest if you have Go 1.25+ installed):
 
 ```shell
 go install github.com/lba-studio/n-cli@latest

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # ✉️ Notification CLI (n-cli) - Send notifications to yourself through the command line
 
-Why stare at your laptop when you can go make yourself a coffee and have your computer let you know when it's done compiling that monstrous 4GB monorepo?
+Why stare at your laptop when you can go make yourself a coffee and have your computer/agent let you know when it's done compiling that monstrous 4GB monorepo?
 
 # 🚀 Features
 
 - Works out-of-the-box - no need to go through any external service (other than your chat apps, of course)
+- Cursor Agent integration – get notifications when the Cursor Agent has finished doing its task (see [Cursor integration](#cursor-agents))
 - Desktop notification
 - Discord notification through [Discord webhooks](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks)
 - Slack notification through [Slack workflow webhooks](https://slack.com/intl/en-gb/help/articles/360041352714-Create-workflows-that-start-with-a-webhook)
@@ -55,10 +56,23 @@ n-cli r -- make build --whatever-args-i-have-here
 alias n="n-cli s"
 make build; n Build is done;
 
+# integrations with LLM agents
+n-cli setup cursor # set up Cursor hooks so you get notified when the agent finishes or session ends
+
 # useful commands
 n-cli init # optional: initializes & configures n-cli without running anything
 n-cli where config # where is your config?
 n-cli version # get version
+```
+
+# 🔌 Integrations
+
+## Cursor Agent
+
+Get notifications when the Cursor Agent stops or when the session ends.
+
+```sh
+n-cli setup cursor # attaches n-cli to ~/.cursor/hooks.json
 ```
 
 # 📝 Configuration

--- a/cmd/cmd_setup.go
+++ b/cmd/cmd_setup.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/lba-studio/n-cli/cmd/setup"
+	"github.com/spf13/cobra"
+)
+
+func NewSetupCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "setup",
+		Short: "Set up integrations (e.g. Cursor hooks).",
+	}
+	c.AddCommand(setup.NewSetupCursorCmd())
+	return c
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,6 +35,7 @@ func init() {
 		NewInitCmd(),
 		NewVersionCmd(),
 		NewRunCmd(),
+		NewSetupCmd(),
 	)
 }
 

--- a/cmd/setup/cmd_cursor.go
+++ b/cmd/setup/cmd_cursor.go
@@ -36,7 +36,7 @@ case "$event" in
     msg="Done: agent finished (status: ${status:-unknown})"
     ;;
   sessionEnd)
-    msg="Session ended"
+    exit 0 # we don't actually care about sessionEnd since the agent is just being closed by the user
     ;;
   *)
     msg="Cursor hook: ${event:-unknown}\nFull payload: ${input:-no_input}"

--- a/cmd/setup/cmd_cursor.go
+++ b/cmd/setup/cmd_cursor.go
@@ -1,0 +1,205 @@
+package setup
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/cqroot/prompt"
+	"github.com/spf13/cobra"
+)
+
+const (
+	cursorDir      = ".cursor"
+	cursorHooksDir = "hooks"
+	hooksJSON      = "hooks.json"
+	hookScriptName = "n-cli-notify.sh"
+	hookCommand    = "./hooks/n-cli-notify.sh"
+)
+
+var hookScriptContent = `#!/bin/sh
+# n-cli Cursor hook: notifies via n-cli send --stdin when agent stops or session ends.
+# Receives JSON on stdin from Cursor (hook_event_name, status for stop, etc.).
+input=""
+while IFS= read -r line; do
+  input="${input}${line}"
+done
+
+event=$(echo "$input" | sed -n 's/.*"hook_event_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+status=$(echo "$input" | sed -n 's/.*"status"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+
+case "$event" in
+  stop)
+    msg="Done: agent finished (status: ${status:-unknown})"
+    ;;
+  sessionEnd)
+    msg="Session ended"
+    ;;
+  *)
+    msg="Cursor hook: ${event:-unknown}"
+    ;;
+esac
+
+echo "$msg" | n-cli send --stdin 2>/dev/null || true
+exit 0
+`
+
+func NewSetupCursorCmd() *cobra.Command {
+	var force bool
+	c := &cobra.Command{
+		Use:   "cursor",
+		Short: "Set up Cursor hooks so you get n-cli notifications when the agent finishes or the session ends.",
+		Long: `Writes user-level Cursor hooks to ~/.cursor/ so that when the agent loop ends (stop)
+or the session ends (sessionEnd), a script runs and calls n-cli send --stdin to notify you.
+
+Requires n-cli to be on PATH. After setup, keep n-cli on PATH in the
+shell environment Cursor uses so hooks can run.
+
+To get notifications when the agent needs your input, add a per-project rule in .cursor/rules/
+that tells the agent to run: echo "Need input: <question>" | n-cli send --stdin`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSetupCursor(force)
+		},
+	}
+	c.Flags().BoolVar(&force, "force", false, "Overwrite existing hook script without prompting")
+	return c
+}
+
+func runSetupCursor(force bool) error {
+	if _, err := exec.LookPath("n-cli"); err != nil {
+		fmt.Fprintf(os.Stderr, "n-cli is not on PATH; add it to your PATH so Cursor can run it from hooks.\n")
+		fmt.Fprintf(os.Stderr, "Check your shell profile (e.g. ~/.zshrc) and restart Cursor after setup.\n")
+		os.Exit(1)
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("home directory: %w", err)
+	}
+	cursorPath := filepath.Join(home, cursorDir)
+	hooksPath := filepath.Join(cursorPath, cursorHooksDir)
+	hooksJSONPath := filepath.Join(cursorPath, hooksJSON)
+	scriptPath := filepath.Join(hooksPath, hookScriptName)
+
+	if err := os.MkdirAll(hooksPath, 0700); err != nil {
+		return fmt.Errorf("create %s: %w", hooksPath, err)
+	}
+
+	if err := mergeHooksJSON(hooksJSONPath); err != nil {
+		return err
+	}
+
+	if _, err := os.Stat(scriptPath); err == nil && !force {
+		overwrite, err := prompt.New().
+			Ask(fmt.Sprintf("Hook script already exists at %s. Overwrite?", scriptPath)).
+			Choose([]string{"Yes", "No"})
+		if err != nil {
+			return fmt.Errorf("prompt: %w", err)
+		}
+		if overwrite != "Yes" {
+			fmt.Println("Skipping hook script. Run with --force to overwrite.")
+			printSuccess(hooksJSONPath, scriptPath)
+			return nil
+		}
+	}
+
+	if err := os.WriteFile(scriptPath, []byte(hookScriptContent), 0700); err != nil {
+		return fmt.Errorf("write hook script: %w", err)
+	}
+	if err := os.Chmod(scriptPath, 0755); err != nil {
+		return fmt.Errorf("chmod hook script: %w", err)
+	}
+
+	printSuccess(hooksJSONPath, scriptPath)
+	return nil
+}
+
+func mergeHooksJSON(hooksJSONPath string) error {
+	var root struct {
+		Version int                    `json:"version"`
+		Hooks   map[string]interface{} `json:"hooks"`
+	}
+	root.Version = 1
+	root.Hooks = make(map[string]interface{})
+
+	data, err := os.ReadFile(hooksJSONPath)
+	if err == nil {
+		if err := json.Unmarshal(data, &root); err != nil {
+			return fmt.Errorf("parse existing %s: %w", hooksJSONPath, err)
+		}
+		if root.Hooks == nil {
+			root.Hooks = make(map[string]interface{})
+		}
+	}
+
+	for _, event := range []string{"stop", "sessionEnd"} {
+		root.Hooks[event] = mergeHookEntry(root.Hooks[event], hookCommand)
+	}
+
+	out, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal hooks.json: %w", err)
+	}
+	if err := os.WriteFile(hooksJSONPath, out, 0644); err != nil {
+		return fmt.Errorf("write %s: %w", hooksJSONPath, err)
+	}
+	return nil
+}
+
+func mergeHookEntry(existing interface{}, command string) []map[string]string {
+	entry := map[string]string{"command": command}
+	var list []map[string]string
+	switch v := existing.(type) {
+	case []interface{}:
+		for _, i := range v {
+			if m, ok := i.(map[string]interface{}); ok {
+				if c, _ := m["command"].(string); c == command {
+					return sliceFromInterface(v)
+				}
+				list = append(list, mapFromInterface(m))
+			}
+		}
+	case nil:
+	default:
+		if arr, ok := existing.([]map[string]string); ok {
+			for _, m := range arr {
+				if m["command"] == command {
+					return arr
+				}
+				list = append(list, m)
+			}
+		}
+	}
+	list = append(list, entry)
+	return list
+}
+
+func sliceFromInterface(s []interface{}) []map[string]string {
+	out := make([]map[string]string, 0, len(s))
+	for _, i := range s {
+		if m, ok := i.(map[string]interface{}); ok {
+			out = append(out, mapFromInterface(m))
+		}
+	}
+	return out
+}
+
+func mapFromInterface(m map[string]interface{}) map[string]string {
+	out := make(map[string]string)
+	for k, v := range m {
+		if s, ok := v.(string); ok {
+			out[k] = s
+		}
+	}
+	return out
+}
+
+func printSuccess(hooksJSONPath, scriptPath string) {
+	fmt.Printf("Cursor hooks configured.\n")
+	fmt.Printf("  %s\n", hooksJSONPath)
+	fmt.Printf("  %s\n", scriptPath)
+	fmt.Println("Restart Cursor for hooks to take effect. Ensure n-cli stays on PATH in the shell Cursor uses.")
+}

--- a/cmd/setup/cmd_cursor.go
+++ b/cmd/setup/cmd_cursor.go
@@ -24,7 +24,7 @@ var hookScriptContent = `#!/bin/sh
 # n-cli Cursor hook: notifies via n-cli send --stdin when agent stops or session ends.
 # Receives JSON on stdin from Cursor (hook_event_name, status for stop, etc.).
 input=""
-while IFS= read -r line; do
+while IFS= read -r line || [ -n "$line" ]; do
   input="${input}${line}"
 done
 
@@ -39,7 +39,7 @@ case "$event" in
     msg="Session ended"
     ;;
   *)
-    msg="Cursor hook: ${event:-unknown}"
+    msg="Cursor hook: ${event:-unknown}\nFull payload: ${input:-no_input}"
     ;;
 esac
 

--- a/cmd/setup/cmd_cursor_test.go
+++ b/cmd/setup/cmd_cursor_test.go
@@ -1,0 +1,215 @@
+package setup
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSetupCursorCmd(t *testing.T) {
+	c := NewSetupCursorCmd()
+	require.NotNil(t, c)
+	assert.Equal(t, "cursor", c.Name())
+	assert.Equal(t, "Set up Cursor hooks so you get n-cli notifications when the agent finishes or the session ends.", c.Short)
+	assert.NotEmpty(t, c.Long)
+	f := c.Flags().Lookup("force")
+	require.NotNil(t, f)
+	assert.Equal(t, "false", f.DefValue)
+}
+
+func TestMergeHookEntry(t *testing.T) {
+	cmd := hookCommand
+	tests := []struct {
+		name     string
+		existing interface{}
+		command  string
+		wantLen  int
+		wantSame bool
+	}{
+		{
+			name:     "nil existing",
+			existing: nil,
+			command:  cmd,
+			wantLen:  1,
+			wantSame: false,
+		},
+		{
+			name:     "non-slice existing",
+			existing: "not a slice",
+			command:  cmd,
+			wantLen:  1,
+			wantSame: false,
+		},
+		{
+			name:     "empty slice",
+			existing: []interface{}{},
+			command:  cmd,
+			wantLen:  1,
+			wantSame: false,
+		},
+		{
+			name: "slice without our command",
+			existing: []interface{}{
+				map[string]interface{}{"command": "other-script.sh"},
+			},
+			command:  cmd,
+			wantLen:  2,
+			wantSame: false,
+		},
+		{
+			name: "slice with our command already",
+			existing: []interface{}{
+				map[string]interface{}{"command": cmd},
+			},
+			command:  cmd,
+			wantLen:  1,
+			wantSame: true,
+		},
+		{
+			name: "slice with our command and others",
+			existing: []interface{}{
+				map[string]interface{}{"command": "other.sh"},
+				map[string]interface{}{"command": cmd},
+			},
+			command:  cmd,
+			wantLen:  2,
+			wantSame: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeHookEntry(tt.existing, tt.command)
+			assert.Len(t, got, tt.wantLen)
+			var hasCommand bool
+			for _, e := range got {
+				if m, ok := e.(map[string]interface{}); ok {
+					if c, _ := m["command"].(string); c == tt.command {
+						hasCommand = true
+						break
+					}
+				}
+				if m, ok := e.(map[string]string); ok {
+					if m["command"] == tt.command {
+						hasCommand = true
+						break
+					}
+				}
+			}
+			if tt.wantLen >= 1 {
+				assert.True(t, hasCommand, "result should contain command %q", tt.command)
+			}
+			if tt.wantSame && tt.existing != nil {
+				if existingSlice, ok := tt.existing.([]interface{}); ok {
+					assert.Same(t, &existingSlice[0], &got[0])
+				}
+			}
+		})
+	}
+}
+
+func TestMergeHooksJSON_NoExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.json")
+
+	err := mergeHooksJSON(path)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var root map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &root))
+	assert.Equal(t, float64(1), root["version"])
+	hooks, ok := root["hooks"].(map[string]interface{})
+	require.True(t, ok)
+	for _, event := range []string{"stop", "sessionEnd"} {
+		entries, ok := hooks[event].([]interface{})
+		require.True(t, ok, "hooks[%s] should be slice", event)
+		require.Len(t, entries, 1)
+		entry, ok := entries[0].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, hookCommand, entry["command"])
+	}
+}
+
+func TestMergeHooksJSON_ExistingEmptyObject(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.json")
+	require.NoError(t, os.WriteFile(path, []byte("{}"), 0644))
+
+	err := mergeHooksJSON(path)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var root map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &root))
+	assert.Equal(t, float64(1), root["version"])
+	hooks, ok := root["hooks"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, hookCommand, hooks["stop"].([]interface{})[0].(map[string]interface{})["command"])
+	assert.Equal(t, hookCommand, hooks["sessionEnd"].([]interface{})[0].(map[string]interface{})["command"])
+}
+
+func TestMergeHooksJSON_ExistingWithHooksNoVersion(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.json")
+	existing := map[string]interface{}{
+		"hooks": map[string]interface{}{
+			"stop": []interface{}{map[string]interface{}{"command": "existing.sh"}},
+		},
+	}
+	raw, _ := json.Marshal(existing)
+	require.NoError(t, os.WriteFile(path, raw, 0644))
+
+	err := mergeHooksJSON(path)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var root map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &root))
+	assert.Equal(t, float64(1), root["version"])
+	hooks := root["hooks"].(map[string]interface{})
+	stopEntries := hooks["stop"].([]interface{})
+	require.Len(t, stopEntries, 2)
+	assert.Equal(t, "existing.sh", stopEntries[0].(map[string]interface{})["command"])
+	assert.Equal(t, hookCommand, stopEntries[1].(map[string]interface{})["command"])
+	sessionEndEntries := hooks["sessionEnd"].([]interface{})
+	require.Len(t, sessionEndEntries, 1)
+	assert.Equal(t, hookCommand, sessionEndEntries[0].(map[string]interface{})["command"])
+}
+
+func TestMergeHooksJSON_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.json")
+	require.NoError(t, os.WriteFile(path, []byte("not json"), 0644))
+
+	err := mergeHooksJSON(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse existing")
+}
+
+func TestMergeHooksJSON_SecondCallPreservesHooks(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0700))
+	existing := map[string]interface{}{
+		"hooks": map[string]interface{}{},
+	}
+	raw, _ := json.Marshal(existing)
+	require.NoError(t, os.WriteFile(path, raw, 0644))
+
+	require.NoError(t, mergeHooksJSON(path))
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var root map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &root))
+	hooks := root["hooks"].(map[string]interface{})
+	stopEntries := hooks["stop"].([]interface{})
+	require.Len(t, stopEntries, 1)
+	assert.Equal(t, hookCommand, stopEntries[0].(map[string]interface{})["command"])
+}

--- a/cmd/setup/cmd_cursor_test.go
+++ b/cmd/setup/cmd_cursor_test.go
@@ -14,7 +14,6 @@ func TestNewSetupCursorCmd(t *testing.T) {
 	c := NewSetupCursorCmd()
 	require.NotNil(t, c)
 	assert.Equal(t, "cursor", c.Name())
-	assert.Equal(t, "Set up Cursor hooks so you get n-cli notifications when the agent finishes or the session ends.", c.Short)
 	assert.NotEmpty(t, c.Long)
 	f := c.Flags().Lookup("force")
 	require.NotNil(t, f)


### PR DESCRIPTION
Changes:
- added `n-cli send --stdin` to accept inputs from stdin (note, there are currently no limits on the stdin input - do let me know if anyone's keen on having `maxInputLength` for n-cli's `config.yaml`).
- added `n-cli setup cursor` to enable notifications when Cursor Agent has finished their task (tested on the Desktop IDE).

Note that I haven't tested the "agents are asking for input/approval" flow when doing things like "executing non-sandbox commands" and "fetching external web resources" (next TODO I guess)