### PR TITLE
Fix Codex Stop hook JSON output

### DIFF
--- a/cmd/hook/cmd_codex.go
+++ b/cmd/hook/cmd_codex.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -22,28 +21,39 @@ func NewHookCodexCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			data, err := io.ReadAll(cmd.InOrStdin())
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "n-cli hook error: read stdin: %s\n", err)
+				fmt.Fprintf(cmd.ErrOrStderr(), "n-cli hook error: read stdin: %s\n", err)
 				return
 			}
-			if err := HandleHookCodex(data); err != nil {
-				fmt.Fprintf(os.Stderr, "n-cli hook error: %s\n", err)
+			output, err := HandleHookCodex(data)
+			if len(output) > 0 {
+				if _, writeErr := cmd.OutOrStdout().Write(output); writeErr != nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "n-cli hook error: write output: %s\n", writeErr)
+				}
+			}
+			if err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "n-cli hook error: %s\n", err)
 			}
 		},
 	}
 }
 
-func HandleHookCodex(data []byte) error {
+func HandleHookCodex(data []byte) ([]byte, error) {
 	var payload codexHookPayload
 	if err := json.Unmarshal(data, &payload); err != nil {
-		return fmt.Errorf("parse hook JSON: %w", err)
+		return nil, fmt.Errorf("parse hook JSON: %w", err)
+	}
+
+	var output []byte
+	if payload.HookEventName == "Stop" {
+		output = []byte("{\"continue\":true}\n")
 	}
 
 	msg := FormatCodexMessage(payload)
 	if msg == "" {
-		return nil
+		return output, nil
 	}
 
-	return notify(msg)
+	return output, notify(msg)
 }
 
 func FormatCodexMessage(payload codexHookPayload) string {

--- a/cmd/hook/cmd_codex_test.go
+++ b/cmd/hook/cmd_codex_test.go
@@ -1,6 +1,9 @@
 package hook
 
 import (
+	"bytes"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -97,7 +100,7 @@ func TestHandleHookCodex(t *testing.T) {
 				return nil
 			}
 
-			err := HandleHookCodex(tt.data)
+			_, err := HandleHookCodex(tt.data)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -108,6 +111,68 @@ func TestHandleHookCodex(t *testing.T) {
 				assert.Equal(t, tt.wantMsg, gotMsg)
 			} else {
 				assert.Empty(t, gotMsg)
+			}
+		})
+	}
+}
+
+func TestHookCodexCommandOutput(t *testing.T) {
+	originalNotify := notify
+	t.Cleanup(func() {
+		notify = originalNotify
+	})
+
+	tests := []struct {
+		name       string
+		input      string
+		wantMsg    string
+		wantStdout string
+		notifyErr  error
+		wantStderr string
+	}{
+		{
+			name:       "stop writes valid JSON",
+			input:      `{"hook_event_name":"Stop"}`,
+			wantMsg:    "Codex agent finished",
+			wantStdout: `{"continue":true}`,
+		},
+		{
+			name:       "stop writes valid JSON when notification fails",
+			input:      `{"hook_event_name":"Stop"}`,
+			wantMsg:    "Codex agent finished",
+			wantStdout: `{"continue":true}`,
+			notifyErr:  errors.New("boom"),
+			wantStderr: "n-cli hook error: boom\n",
+		},
+		{
+			name:    "permission request writes no stdout",
+			input:   `{"hook_event_name":"PermissionRequest","tool_name":"shell"}`,
+			wantMsg: "Codex needs approval for: shell",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotMsg string
+			notify = func(msg string) error {
+				gotMsg = msg
+				return tt.notifyErr
+			}
+
+			cmd := NewHookCodexCmd()
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			cmd.SetIn(strings.NewReader(tt.input))
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&stderr)
+
+			require.NoError(t, cmd.Execute())
+			assert.Equal(t, tt.wantStderr, stderr.String())
+			assert.Equal(t, tt.wantMsg, gotMsg)
+			if tt.wantStdout == "" {
+				assert.Empty(t, stdout.String())
+			} else {
+				assert.JSONEq(t, tt.wantStdout, stdout.String())
 			}
 		})
 	}

--- a/cmd/hook/notify.go
+++ b/cmd/hook/notify.go
@@ -1,7 +1,13 @@
 package hook
 
-import "github.com/lba-studio/n-cli/pkg/notifier"
+import (
+	"os"
+
+	"github.com/lba-studio/n-cli/pkg/notifier"
+)
 
 type notifyFunc func(msg string) error
 
-var notify notifyFunc = notifier.Notify
+var notify notifyFunc = func(msg string) error {
+	return notifier.NotifyTo(msg, os.Stderr)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,7 +57,7 @@ func initConfig() {
 
 	if err := viper.ReadInConfig(); err != nil {
 		// fmt.Println("Using config file:", viper.ConfigFileUsed())
-		fmt.Printf("WARN: Cannot read config: %s\n", err.Error())
+		fmt.Fprintf(os.Stderr, "WARN: Cannot read config: %s\n", err.Error())
 	}
 }
 

--- a/pkg/notifier/notify.go
+++ b/pkg/notifier/notify.go
@@ -3,6 +3,8 @@ package notifier
 import (
 	"context"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -15,6 +17,10 @@ type Notifier interface {
 }
 
 func Notify(msg string) error {
+	return NotifyTo(msg, os.Stdout)
+}
+
+func NotifyTo(msg string, output io.Writer) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -41,7 +47,7 @@ func Notify(msg string) error {
 		labels = append(labels, label)
 	}
 
-	fmt.Printf("Sending notification to %d channels: %s\n", len(notifierMap), strings.Join(labels, ", "))
+	fmt.Fprintf(output, "Sending notification to %d channels: %s\n", len(notifierMap), strings.Join(labels, ", "))
 
 	erroredNotifiers := make([]string, 0, len(notifierMap))
 	wg := sync.WaitGroup{}
@@ -52,11 +58,11 @@ func Notify(msg string) error {
 			defer wg.Done()
 			logPrefix := fmt.Sprintf("Sent notification to %s", label)
 			if err := notifier.Notify(ctx, msg); err != nil {
-				fmt.Printf("%s...ERROR (%s)\n", logPrefix, err.Error())
+				fmt.Fprintf(output, "%s...ERROR (%s)\n", logPrefix, err.Error())
 				erroredNotifiersChan <- label
 				return
 			}
-			fmt.Printf("%s...OK\n", logPrefix)
+			fmt.Fprintf(output, "%s...OK\n", logPrefix)
 		}(label, notifier)
 	}
 	go func() {


### PR DESCRIPTION
## Summary
- ensure Codex Stop hooks return JSON-only stdout
- route hook notification logs and config warnings to stderr
- document the Codex failure mode in README

## Issue
Codex Stop hooks treat successful stdout as a JSON response. n-cli previously wrote notification progress logs to stdout, causing Codex to report `hook returned invalid stop hook JSON output`.

## Tests
- `env GOCACHE=/private/tmp/n-cli-go-build-cache go test ./...`