### PR TITLE
feat: allow ignoring hook events

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ make build; n Build is done;
 n-cli setup cursor       # set up Cursor hooks so you get notified when the agent finishes or session ends
 n-cli setup codex        # set up Codex hooks so you get notified when the agent finishes or needs approval
 n-cli setup claude-code  # set up Claude Code hooks so you get notified when the agent finishes or needs approval
+n-cli setup codex --ignored-events=PermissionRequest # skip notifications for selected hook events
 
 # useful commands
 n-cli init # optional: initializes & configures n-cli without running anything
@@ -75,7 +76,10 @@ Get notifications when the Cursor Agent stops or when the session ends.
 
 ```sh
 n-cli setup cursor # registers n-cli hook cursor in ~/.cursor/hooks.json
+n-cli setup cursor --ignored-events=sessionEnd
 ```
+
+Known Cursor hook events registered by n-cli: `stop`, `sessionEnd`.
 
 ## Codex
 
@@ -83,9 +87,12 @@ Get notifications when Codex finishes a turn (`Stop`) or is waiting for your app
 
 ```sh
 n-cli setup codex # registers n-cli hook codex in ~/.codex/hooks.json
+n-cli setup codex --ignored-events=PermissionRequest
 ```
 
 After setup, restart Codex and review/trust the hooks with `/hooks` if prompted. Ensure `n-cli` stays on your PATH in the shell environment Codex uses.
+
+Known Codex hook events registered by n-cli: `Stop`, `PermissionRequest`.
 
 ## Claude Code
 
@@ -93,9 +100,14 @@ Get notifications when the Claude Code agent finishes (`Stop`) or needs your app
 
 ```sh
 n-cli setup claude-code # registers n-cli hook claude-code in ~/.claude/settings.json
+n-cli setup claude-code --ignored-events=Notification
 ```
 
 After setup, restart Claude Code and review/trust the hooks with `/hooks` if prompted. Ensure `n-cli` stays on your PATH in the shell environment Claude Code uses.
+
+Known Claude Code hook events registered by n-cli: `Stop`, `Notification`.
+
+`--ignored-events` accepts comma-separated event names. Event matching is exact and case-sensitive against `hook_event_name`, and unknown future event names are allowed.
 
 # 📝 Configuration
 
@@ -123,4 +135,18 @@ custom: # if missing, n-cli won't use custom webhook as a notification channel
   headers: # optional - custom HTTP headers
     Authorization: Bearer your-token-here
     X-Custom-Header: custom-value
+
+hooks: # optional - per-agent hook notification preferences
+  codex:
+    setup: true
+    ignored_events:
+      - PermissionRequest
+  claude_code:
+    setup: true
+    ignored_events:
+      - Notification
+  cursor:
+    setup: true
+    ignored_events:
+      - stop
 ```

--- a/cmd/hook/cmd_claude_code.go
+++ b/cmd/hook/cmd_claude_code.go
@@ -51,6 +51,14 @@ func HandleHookClaudeCode(data []byte) error {
 		return nil
 	}
 
+	ignored, err := isHookEventIgnored(hookAgentClaudeCode, payload.HookEventName)
+	if err != nil {
+		return err
+	}
+	if ignored {
+		return nil
+	}
+
 	msg := FormatClaudeCodeMessage(payload)
 	if msg == "" {
 		return nil

--- a/cmd/hook/cmd_claude_code_test.go
+++ b/cmd/hook/cmd_claude_code_test.go
@@ -3,6 +3,7 @@ package hook
 import (
 	"testing"
 
+	"github.com/lba-studio/n-cli/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -75,6 +76,7 @@ func TestHandleHookClaudeCode(t *testing.T) {
 	t.Cleanup(func() {
 		notify = originalNotify
 	})
+	stubHookConfig(t, config.Config{})
 
 	tests := []struct {
 		name      string
@@ -140,4 +142,52 @@ func TestHandleHookClaudeCode(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandleHookClaudeCodeIgnoredEvent(t *testing.T) {
+	originalNotify := notify
+	t.Cleanup(func() {
+		notify = originalNotify
+	})
+	stubHookConfig(t, config.Config{
+		Hooks: &config.HooksConfig{
+			ClaudeCode: &config.HookAgentConfig{
+				IgnoredEvents: []string{"Notification"},
+			},
+		},
+	})
+
+	var gotMsg string
+	notify = func(msg string) error {
+		gotMsg = msg
+		return nil
+	}
+
+	err := HandleHookClaudeCode([]byte(`{"hook_event_name":"Notification","notification_type":"permission_prompt","message":"approve?"}`))
+	require.NoError(t, err)
+	assert.Empty(t, gotMsg)
+}
+
+func TestHandleHookClaudeCodeNonIgnoredEvent(t *testing.T) {
+	originalNotify := notify
+	t.Cleanup(func() {
+		notify = originalNotify
+	})
+	stubHookConfig(t, config.Config{
+		Hooks: &config.HooksConfig{
+			ClaudeCode: &config.HookAgentConfig{
+				IgnoredEvents: []string{"Notification"},
+			},
+		},
+	})
+
+	var gotMsg string
+	notify = func(msg string) error {
+		gotMsg = msg
+		return nil
+	}
+
+	err := HandleHookClaudeCode([]byte(`{"hook_event_name":"Stop"}`))
+	require.NoError(t, err)
+	assert.Equal(t, "Claude Code agent finished", gotMsg)
 }

--- a/cmd/hook/cmd_codex.go
+++ b/cmd/hook/cmd_codex.go
@@ -48,6 +48,14 @@ func HandleHookCodex(data []byte) ([]byte, error) {
 		output = []byte("{\"continue\":true}\n")
 	}
 
+	ignored, err := isHookEventIgnored(hookAgentCodex, payload.HookEventName)
+	if err != nil {
+		return output, err
+	}
+	if ignored {
+		return output, nil
+	}
+
 	msg := FormatCodexMessage(payload)
 	if msg == "" {
 		return output, nil

--- a/cmd/hook/cmd_codex_test.go
+++ b/cmd/hook/cmd_codex_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/lba-studio/n-cli/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -59,6 +60,7 @@ func TestHandleHookCodex(t *testing.T) {
 	t.Cleanup(func() {
 		notify = originalNotify
 	})
+	stubHookConfig(t, config.Config{})
 
 	tests := []struct {
 		name      string
@@ -116,11 +118,62 @@ func TestHandleHookCodex(t *testing.T) {
 	}
 }
 
+func TestHandleHookCodexIgnoredEvent(t *testing.T) {
+	originalNotify := notify
+	t.Cleanup(func() {
+		notify = originalNotify
+	})
+	stubHookConfig(t, config.Config{
+		Hooks: &config.HooksConfig{
+			Codex: &config.HookAgentConfig{
+				IgnoredEvents: []string{"PermissionRequest", "Stop"},
+			},
+		},
+	})
+
+	var gotMsg string
+	notify = func(msg string) error {
+		gotMsg = msg
+		return nil
+	}
+
+	output, err := HandleHookCodex([]byte(`{"hook_event_name":"Stop"}`))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"continue":true}`, string(output))
+	assert.Empty(t, gotMsg)
+}
+
+func TestHandleHookCodexNonIgnoredEvent(t *testing.T) {
+	originalNotify := notify
+	t.Cleanup(func() {
+		notify = originalNotify
+	})
+	stubHookConfig(t, config.Config{
+		Hooks: &config.HooksConfig{
+			Codex: &config.HookAgentConfig{
+				IgnoredEvents: []string{"PermissionRequest"},
+			},
+		},
+	})
+
+	var gotMsg string
+	notify = func(msg string) error {
+		gotMsg = msg
+		return nil
+	}
+
+	output, err := HandleHookCodex([]byte(`{"hook_event_name":"Stop"}`))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"continue":true}`, string(output))
+	assert.Equal(t, "Codex agent finished", gotMsg)
+}
+
 func TestHookCodexCommandOutput(t *testing.T) {
 	originalNotify := notify
 	t.Cleanup(func() {
 		notify = originalNotify
 	})
+	stubHookConfig(t, config.Config{})
 
 	tests := []struct {
 		name       string

--- a/cmd/hook/cmd_cursor.go
+++ b/cmd/hook/cmd_cursor.go
@@ -38,6 +38,14 @@ func HandleHookCursor(data []byte) error {
 		return fmt.Errorf("parse hook JSON: %w", err)
 	}
 
+	ignored, err := isHookEventIgnored(hookAgentCursor, payload.HookEventName)
+	if err != nil {
+		return err
+	}
+	if ignored {
+		return nil
+	}
+
 	msg := FormatCursorMessage(payload)
 	if msg == "" {
 		return nil

--- a/cmd/hook/cmd_cursor_test.go
+++ b/cmd/hook/cmd_cursor_test.go
@@ -3,6 +3,7 @@ package hook
 import (
 	"testing"
 
+	"github.com/lba-studio/n-cli/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -61,6 +62,7 @@ func TestHandleHookCursor(t *testing.T) {
 	t.Cleanup(func() {
 		notify = originalNotify
 	})
+	stubHookConfig(t, config.Config{})
 
 	tests := []struct {
 		name      string
@@ -115,4 +117,52 @@ func TestHandleHookCursor(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandleHookCursorIgnoredEvent(t *testing.T) {
+	originalNotify := notify
+	t.Cleanup(func() {
+		notify = originalNotify
+	})
+	stubHookConfig(t, config.Config{
+		Hooks: &config.HooksConfig{
+			Cursor: &config.HookAgentConfig{
+				IgnoredEvents: []string{"stop"},
+			},
+		},
+	})
+
+	var gotMsg string
+	notify = func(msg string) error {
+		gotMsg = msg
+		return nil
+	}
+
+	err := HandleHookCursor([]byte(`{"hook_event_name":"stop","status":"completed"}`))
+	require.NoError(t, err)
+	assert.Empty(t, gotMsg)
+}
+
+func TestHandleHookCursorNonIgnoredEvent(t *testing.T) {
+	originalNotify := notify
+	t.Cleanup(func() {
+		notify = originalNotify
+	})
+	stubHookConfig(t, config.Config{
+		Hooks: &config.HooksConfig{
+			Cursor: &config.HookAgentConfig{
+				IgnoredEvents: []string{"sessionEnd"},
+			},
+		},
+	})
+
+	var gotMsg string
+	notify = func(msg string) error {
+		gotMsg = msg
+		return nil
+	}
+
+	err := HandleHookCursor([]byte(`{"hook_event_name":"stop","status":"completed"}`))
+	require.NoError(t, err)
+	assert.Equal(t, "Done: agent finished (status: completed)", gotMsg)
 }

--- a/cmd/hook/config.go
+++ b/cmd/hook/config.go
@@ -1,0 +1,45 @@
+package hook
+
+import (
+	"github.com/lba-studio/n-cli/internal/config"
+)
+
+type hookAgent string
+
+const (
+	hookAgentCursor     hookAgent = config.HookAgentCursorKey
+	hookAgentCodex      hookAgent = config.HookAgentCodexKey
+	hookAgentClaudeCode hookAgent = config.HookAgentClaudeCodeKey
+)
+
+var loadHookConfig = config.GetConfig
+
+func isHookEventIgnored(agent hookAgent, event string) (bool, error) {
+	cfg, err := loadHookConfig()
+	if err != nil {
+		return false, err
+	}
+	if cfg.Hooks == nil {
+		return false, nil
+	}
+
+	var agentCfg *config.HookAgentConfig
+	switch agent {
+	case hookAgentCursor:
+		agentCfg = cfg.Hooks.Cursor
+	case hookAgentCodex:
+		agentCfg = cfg.Hooks.Codex
+	case hookAgentClaudeCode:
+		agentCfg = cfg.Hooks.ClaudeCode
+	}
+	if agentCfg == nil {
+		return false, nil
+	}
+
+	for _, ignored := range agentCfg.IgnoredEvents {
+		if event == ignored {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/cmd/hook/config_test.go
+++ b/cmd/hook/config_test.go
@@ -1,0 +1,18 @@
+package hook
+
+import (
+	"testing"
+
+	"github.com/lba-studio/n-cli/internal/config"
+)
+
+func stubHookConfig(t *testing.T, cfg config.Config) {
+	t.Helper()
+	original := loadHookConfig
+	loadHookConfig = func() (config.Config, error) {
+		return cfg, nil
+	}
+	t.Cleanup(func() {
+		loadHookConfig = original
+	})
+}

--- a/cmd/setup/cmd_claude_code.go
+++ b/cmd/setup/cmd_claude_code.go
@@ -20,6 +20,7 @@ const (
 )
 
 func NewSetupClaudeCodeCmd() *cobra.Command {
+	var ignoredEvents string
 	c := &cobra.Command{
 		Use:   "claude-code",
 		Short: "Set up Claude Code hooks so you get n-cli notifications when the agent finishes or needs approval.",
@@ -32,13 +33,17 @@ shell environment Claude Code uses so hooks can run.
 After setup, review and trust the hooks in Claude Code with /hooks if prompted.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runSetupClaudeCode()
+			return runSetupClaudeCode(hookSetupOptions{
+				ignoredEvents:        ignoredEvents,
+				ignoredEventsChanged: cmd.Flags().Changed("ignored-events"),
+			})
 		},
 	}
+	c.Flags().StringVar(&ignoredEvents, "ignored-events", "", "Comma-separated hook event names to skip notifications for.")
 	return c
 }
 
-func runSetupClaudeCode() error {
+func runSetupClaudeCode(opts hookSetupOptions) error {
 	if _, err := exec.LookPath("n-cli"); err != nil {
 		fmt.Fprintf(os.Stderr, "n-cli is not on PATH; add it to your PATH so Claude Code can run it from hooks.\n")
 		fmt.Fprintf(os.Stderr, "%s\n", pathHint())
@@ -57,6 +62,10 @@ func runSetupClaudeCode() error {
 	}
 
 	if err := mergeClaudeCodeSettings(settingsPath, claudeCodeHookCommand); err != nil {
+		return err
+	}
+
+	if err := updateHookSetupConfigForDefaultPath(claudeCodeHookSetupAgent, opts); err != nil {
 		return err
 	}
 

--- a/cmd/setup/cmd_codex.go
+++ b/cmd/setup/cmd_codex.go
@@ -12,13 +12,14 @@ import (
 
 // Codex hooks documentation: https://developers.openai.com/codex/hooks
 const (
-	codexDir          = ".codex"
-	codexHookCommand  = "n-cli hook codex"
+	codexDir         = ".codex"
+	codexHookCommand = "n-cli hook codex"
 )
 
 var codexHookEvents = []string{"Stop", "PermissionRequest"}
 
 func NewSetupCodexCmd() *cobra.Command {
+	var ignoredEvents string
 	c := &cobra.Command{
 		Use:   "codex",
 		Short: "Set up Codex hooks so you get n-cli notifications when the agent finishes or needs approval.",
@@ -31,13 +32,17 @@ shell environment Codex uses so hooks can run.
 After setup, review and trust the hooks in Codex with /hooks if prompted.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runSetupCodex()
+			return runSetupCodex(hookSetupOptions{
+				ignoredEvents:        ignoredEvents,
+				ignoredEventsChanged: cmd.Flags().Changed("ignored-events"),
+			})
 		},
 	}
+	c.Flags().StringVar(&ignoredEvents, "ignored-events", "", "Comma-separated hook event names to skip notifications for.")
 	return c
 }
 
-func runSetupCodex() error {
+func runSetupCodex(opts hookSetupOptions) error {
 	if _, err := exec.LookPath("n-cli"); err != nil {
 		fmt.Fprintf(os.Stderr, "n-cli is not on PATH; add it to your PATH so Codex can run it from hooks.\n")
 		fmt.Fprintf(os.Stderr, "%s\n", pathHint())
@@ -56,6 +61,10 @@ func runSetupCodex() error {
 	}
 
 	if err := mergeCodexHooksJSON(hooksJSONPath, codexHookCommand); err != nil {
+		return err
+	}
+
+	if err := updateHookSetupConfigForDefaultPath(codexHookSetupAgent, opts); err != nil {
 		return err
 	}
 

--- a/cmd/setup/cmd_cursor.go
+++ b/cmd/setup/cmd_cursor.go
@@ -12,13 +12,14 @@ import (
 )
 
 const (
-	cursorDir  = ".cursor"
-	hooksJSON  = "hooks.json"
+	cursorDir   = ".cursor"
+	hooksJSON   = "hooks.json"
 	hookCommand = "n-cli hook cursor"
-	maxVersion = 1 // ensures that hooks.json version changes do not break our integration
+	maxVersion  = 1 // ensures that hooks.json version changes do not break our integration
 )
 
 func NewSetupCursorCmd() *cobra.Command {
+	var ignoredEvents string
 	c := &cobra.Command{
 		Use:   "cursor",
 		Short: "Set up Cursor hooks so you get n-cli notifications when the agent finishes or the session ends.",
@@ -32,13 +33,17 @@ To get notifications when the agent needs your input, add a per-project rule in 
 that tells the agent to run: echo "Need input: <question>" | n-cli send --stdin`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runSetupCursor()
+			return runSetupCursor(hookSetupOptions{
+				ignoredEvents:        ignoredEvents,
+				ignoredEventsChanged: cmd.Flags().Changed("ignored-events"),
+			})
 		},
 	}
+	c.Flags().StringVar(&ignoredEvents, "ignored-events", "", "Comma-separated hook event names to skip notifications for.")
 	return c
 }
 
-func runSetupCursor() error {
+func runSetupCursor(opts hookSetupOptions) error {
 	if _, err := exec.LookPath("n-cli"); err != nil {
 		fmt.Fprintf(os.Stderr, "n-cli is not on PATH; add it to your PATH so Cursor can run it from hooks.\n")
 		fmt.Fprintf(os.Stderr, "%s\n", pathHint())
@@ -57,6 +62,10 @@ func runSetupCursor() error {
 	}
 
 	if err := mergeHooksJSON(hooksJSONPath); err != nil {
+		return err
+	}
+
+	if err := updateHookSetupConfigForDefaultPath(cursorHookSetupAgent, opts); err != nil {
 		return err
 	}
 

--- a/cmd/setup/hook_config.go
+++ b/cmd/setup/hook_config.go
@@ -1,0 +1,164 @@
+package setup
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/lba-studio/n-cli/internal/config"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+)
+
+type hookSetupAgent struct {
+	configKey string
+}
+
+type hookSetupOptions struct {
+	ignoredEvents        string
+	ignoredEventsChanged bool
+}
+
+var (
+	cursorHookSetupAgent = hookSetupAgent{
+		configKey: config.HookAgentCursorKey,
+	}
+	codexHookSetupAgent = hookSetupAgent{
+		configKey: config.HookAgentCodexKey,
+	}
+	claudeCodeHookSetupAgent = hookSetupAgent{
+		configKey: config.HookAgentClaudeCodeKey,
+	}
+)
+
+func hookConfigPath() (string, error) {
+	if path := viper.ConfigFileUsed(); path != "" {
+		return path, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("home directory: %w", err)
+	}
+	return filepath.Join(home, ".n-cli", "config.yaml"), nil
+}
+
+func updateHookSetupConfigForDefaultPath(agent hookSetupAgent, opts hookSetupOptions) error {
+	path, err := hookConfigPath()
+	if err != nil {
+		return err
+	}
+	return updateHookSetupConfig(path, agent, opts)
+}
+
+func updateHookSetupConfig(configPath string, agent hookSetupAgent, opts hookSetupOptions) error {
+	root, err := readConfigMap(configPath)
+	if err != nil {
+		return err
+	}
+
+	hooks := stringMapValue(root[config.HooksKey])
+	if hooks == nil {
+		hooks = make(map[string]interface{})
+	}
+
+	agentCfg := stringMapValue(hooks[agent.configKey])
+	if agentCfg == nil {
+		agentCfg = make(map[string]interface{})
+	}
+	agentCfg[config.HookSetupKey] = true
+
+	if opts.ignoredEventsChanged {
+		events := parseIgnoredEvents(opts.ignoredEvents)
+		if len(events) == 0 {
+			delete(agentCfg, config.HookIgnoredEventsKey)
+		} else {
+			agentCfg[config.HookIgnoredEventsKey] = events
+		}
+	}
+
+	hooks[agent.configKey] = agentCfg
+	root[config.HooksKey] = hooks
+
+	if err := os.MkdirAll(filepath.Dir(configPath), 0700); err != nil {
+		return fmt.Errorf("create config directory: %w", err)
+	}
+	return writeConfigMap(configPath, root)
+}
+
+func parseIgnoredEvents(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+
+	parts := strings.Split(raw, ",")
+	events := make([]string, 0, len(parts))
+	for _, part := range parts {
+		event := strings.TrimSpace(part)
+		if event == "" {
+			continue
+		}
+		events = append(events, event)
+	}
+	if len(events) == 0 {
+		return nil
+	}
+	return events
+}
+
+func readConfigMap(configPath string) (map[string]interface{}, error) {
+	root := make(map[string]interface{})
+	data, err := os.ReadFile(configPath)
+	if os.IsNotExist(err) {
+		return root, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", configPath, err)
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return root, nil
+	}
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", configPath, err)
+	}
+	if root == nil {
+		root = make(map[string]interface{})
+	}
+	return root, nil
+}
+
+func writeConfigMap(configPath string, root map[string]interface{}) error {
+	perm := os.FileMode(0644)
+	if info, err := os.Stat(configPath); err == nil {
+		perm = info.Mode().Perm()
+	}
+
+	out, err := yaml.Marshal(root)
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	if err := os.WriteFile(configPath, out, perm); err != nil {
+		return fmt.Errorf("write %s: %w", configPath, err)
+	}
+	return nil
+}
+
+func stringMapValue(value interface{}) map[string]interface{} {
+	switch m := value.(type) {
+	case map[string]interface{}:
+		return m
+	case map[interface{}]interface{}:
+		converted := make(map[string]interface{}, len(m))
+		for k, v := range m {
+			key, ok := k.(string)
+			if !ok {
+				continue
+			}
+			converted[key] = v
+		}
+		return converted
+	default:
+		return nil
+	}
+}

--- a/cmd/setup/hook_config_test.go
+++ b/cmd/setup/hook_config_test.go
@@ -1,0 +1,102 @@
+package setup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseIgnoredEvents(t *testing.T) {
+	assert.Equal(t, []string{"PermissionRequest", "Future Event", "Custom"}, parseIgnoredEvents("PermissionRequest, Future Event ,Custom"))
+	assert.Nil(t, parseIgnoredEvents(""))
+	assert.Nil(t, parseIgnoredEvents(" , "))
+}
+
+func TestUpdateHookSetupConfigReplaceAndClearIgnoredEvents(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`system:
+  disabled: true
+hooks:
+  codex:
+    setup: true
+    ignored_events:
+      - Stop
+`), 0644))
+
+	require.NoError(t, updateHookSetupConfig(path, codexHookSetupAgent, hookSetupOptions{
+		ignoredEvents:        "PermissionRequest, Future Event",
+		ignoredEventsChanged: true,
+	}))
+
+	root, err := readConfigMap(path)
+	require.NoError(t, err)
+	system := root["system"].(map[string]interface{})
+	assert.Equal(t, true, system["disabled"])
+	codex := root["hooks"].(map[string]interface{})["codex"].(map[string]interface{})
+	assert.Equal(t, true, codex["setup"])
+	assert.Equal(t, []interface{}{"PermissionRequest", "Future Event"}, codex["ignored_events"])
+
+	require.NoError(t, updateHookSetupConfig(path, codexHookSetupAgent, hookSetupOptions{
+		ignoredEvents:        "",
+		ignoredEventsChanged: true,
+	}))
+
+	root, err = readConfigMap(path)
+	require.NoError(t, err)
+	codex = root["hooks"].(map[string]interface{})["codex"].(map[string]interface{})
+	assert.Equal(t, true, codex["setup"])
+	assert.NotContains(t, codex, "ignored_events")
+}
+
+func TestUpdateHookSetupConfigStoresArbitraryEventNames(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+
+	require.NoError(t, updateHookSetupConfig(path, cursorHookSetupAgent, hookSetupOptions{
+		ignoredEvents:        "not-a-real-event",
+		ignoredEventsChanged: true,
+	}))
+
+	root, err := readConfigMap(path)
+	require.NoError(t, err)
+	cursor := root["hooks"].(map[string]interface{})["cursor"].(map[string]interface{})
+	assert.Equal(t, []interface{}{"not-a-real-event"}, cursor["ignored_events"])
+}
+
+func TestUpdateHookSetupConfigFirstSetup(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+
+	require.NoError(t, updateHookSetupConfig(path, claudeCodeHookSetupAgent, hookSetupOptions{}))
+
+	root, err := readConfigMap(path)
+	require.NoError(t, err)
+	claudeCode := root["hooks"].(map[string]interface{})["claude_code"].(map[string]interface{})
+	assert.Equal(t, true, claudeCode["setup"])
+	assert.NotContains(t, claudeCode, "ignored_events")
+}
+
+func TestUpdateHookSetupConfigExistingAgentKeepsIgnoredEvents(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`hooks:
+  cursor:
+    setup: false
+    ignored_events:
+      - stop
+`), 0644))
+
+	require.NoError(t, updateHookSetupConfig(path, cursorHookSetupAgent, hookSetupOptions{}))
+
+	root, err := readConfigMap(path)
+	require.NoError(t, err)
+	cursor := root["hooks"].(map[string]interface{})["cursor"].(map[string]interface{})
+	assert.Equal(t, true, cursor["setup"])
+	assert.Equal(t, []interface{}{"stop"}, cursor["ignored_events"])
+}
+
+func TestSetupCommandsExposeIgnoredEventsFlag(t *testing.T) {
+	assert.NotNil(t, NewSetupCursorCmd().Flags().Lookup("ignored-events"))
+	assert.NotNil(t, NewSetupCodexCmd().Flags().Lookup("ignored-events"))
+	assert.NotNil(t, NewSetupClaudeCodeCmd().Flags().Lookup("ignored-events"))
+}

--- a/internal/config/config_struct.go
+++ b/internal/config/config_struct.go
@@ -20,10 +20,31 @@ type SystemConfig struct {
 	Disabled bool `mapstructure:"disabled"`
 }
 
+const (
+	HooksKey               = "hooks"
+	HookAgentCodexKey      = "codex"
+	HookAgentClaudeCodeKey = "claude_code"
+	HookAgentCursorKey     = "cursor"
+	HookSetupKey           = "setup"
+	HookIgnoredEventsKey   = "ignored_events"
+)
+
+type HookAgentConfig struct {
+	Setup         bool     `mapstructure:"setup" yaml:"setup"`
+	IgnoredEvents []string `mapstructure:"ignored_events" yaml:"ignored_events,omitempty"`
+}
+
+type HooksConfig struct {
+	Codex      *HookAgentConfig `mapstructure:"codex" yaml:"codex,omitempty"`
+	ClaudeCode *HookAgentConfig `mapstructure:"claude_code" yaml:"claude_code,omitempty"`
+	Cursor     *HookAgentConfig `mapstructure:"cursor" yaml:"cursor,omitempty"`
+}
+
 // Config struct to hold the configuration values
 type Config struct {
-	Discord *DiscordConfig `mapstructure:"discord"`
-	Slack   *SlackConfig   `mapstructure:"slack"`
-	Custom  *CustomConfig  `mapstructure:"custom"`
-	System  *SystemConfig  `mapstructure:"system"`
+	Discord *DiscordConfig `mapstructure:"discord" yaml:"discord,omitempty"`
+	Slack   *SlackConfig   `mapstructure:"slack" yaml:"slack,omitempty"`
+	Custom  *CustomConfig  `mapstructure:"custom" yaml:"custom,omitempty"`
+	System  *SystemConfig  `mapstructure:"system" yaml:"system,omitempty"`
+	Hooks   *HooksConfig   `mapstructure:"hooks" yaml:"hooks,omitempty"`
 }

--- a/internal/config/config_struct_test.go
+++ b/internal/config/config_struct_test.go
@@ -1,0 +1,67 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestHooksConfigUnmarshalSnakeCase(t *testing.T) {
+	input := map[string]interface{}{
+		"hooks": map[string]interface{}{
+			"codex": map[string]interface{}{
+				"setup":          true,
+				"ignored_events": []interface{}{"PermissionRequest"},
+			},
+			"claude_code": map[string]interface{}{
+				"setup":          true,
+				"ignored_events": []interface{}{"Notification"},
+			},
+			"cursor": map[string]interface{}{
+				"setup":          true,
+				"ignored_events": []interface{}{"stop"},
+			},
+		},
+	}
+
+	var cfg Config
+	require.NoError(t, mapstructure.Decode(input, &cfg))
+
+	require.NotNil(t, cfg.Hooks)
+	require.NotNil(t, cfg.Hooks.Codex)
+	require.NotNil(t, cfg.Hooks.ClaudeCode)
+	require.NotNil(t, cfg.Hooks.Cursor)
+	assert.Equal(t, []string{"PermissionRequest"}, cfg.Hooks.Codex.IgnoredEvents)
+	assert.Equal(t, []string{"Notification"}, cfg.Hooks.ClaudeCode.IgnoredEvents)
+	assert.Equal(t, []string{"stop"}, cfg.Hooks.Cursor.IgnoredEvents)
+}
+
+func TestHooksConfigMarshalSnakeCase(t *testing.T) {
+	cfg := Config{
+		Hooks: &HooksConfig{
+			Codex: &HookAgentConfig{
+				Setup:         true,
+				IgnoredEvents: []string{"PermissionRequest"},
+			},
+			ClaudeCode: &HookAgentConfig{
+				Setup:         true,
+				IgnoredEvents: []string{"Notification"},
+			},
+			Cursor: &HookAgentConfig{
+				Setup:         true,
+				IgnoredEvents: []string{"stop"},
+			},
+		},
+	}
+
+	data, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(data), "claude_code:")
+	assert.Contains(t, string(data), "ignored_events:")
+	assert.NotContains(t, string(data), "ClaudeCode")
+	assert.NotContains(t, string(data), "IgnoredEvents")
+}


### PR DESCRIPTION
## Summary

- add per-agent hook config for ignored event names
- wire `--ignored-events` into Cursor, Codex, and Claude Code setup
- skip hook notifications when `hook_event_name` exactly matches configured ignored events
- document the new config and add tests for hook filtering, setup persistence, and config encoding

## Test plan

- `GOCACHE=/private/tmp/n-cli-go-cache go test ./...`

## Review gate

- Ran Minimalist Code Review in fresh-context subagents.
- Applied the first gate finding by removing the partial setup prompt path.
- Follow-up gate reported no actionable findings.
